### PR TITLE
Potential fix for code scanning alert no. 17: DOM text reinterpreted as HTML

### DIFF
--- a/portfolai/staticfiles/home/js/stock.js
+++ b/portfolai/staticfiles/home/js/stock.js
@@ -990,6 +990,15 @@ function createWidgetConfig(symbol, exchange, theme) {
  * @param {Object} config - Widget configuration object
  * @returns {Object} Object containing widget div and copyright div references
  */
+function escapeHTML(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function createWidgetStructure(container, symbol, exchange, config) {
   // Create widget div
   const widgetDiv = document.createElement('div');
@@ -1008,7 +1017,9 @@ function createWidgetStructure(container, symbol, exchange, config) {
   // Create copyright attribution (required by TradingView)
   const copyrightDiv = document.createElement('div');
   copyrightDiv.className = 'tradingview-widget-copyright';
-  copyrightDiv.innerHTML = `<a href="https://www.tradingview.com/symbols/${exchange}-${symbol}/" rel="noopener nofollow" target="_blank"><span class="blue-text">${symbol}</span></a><span class="trademark"> by TradingView</span>`;
+  const safeSymbol = escapeHTML(symbol);
+  const safeExchange = escapeHTML(exchange);
+  copyrightDiv.innerHTML = `<a href="https://www.tradingview.com/symbols/${safeExchange}-${safeSymbol}/" rel="noopener nofollow" target="_blank"><span class="blue-text">${safeSymbol}</span></a><span class="trademark"> by TradingView</span>`;
   container.appendChild(copyrightDiv);
   
   return { widgetDiv, copyrightDiv };


### PR DESCRIPTION
Potential fix for [https://github.com/eduran04/PortfolAI-CS4300-Fall-2024-Group-4/security/code-scanning/17](https://github.com/eduran04/PortfolAI-CS4300-Fall-2024-Group-4/security/code-scanning/17)

To fix the vulnerability, we must ensure that any user-supplied string interpolated into `innerHTML` is properly escaped so that any special HTML meta-characters (`<`, `>`, `&`, `"`, `'`) are rendered as literal characters, not interpreted as HTML. The best practice is to use contextual output encoding before inserting untrusted data into HTML. For this case, we should create a utility function that escapes dangerous characters from `symbol` and `exchange` before using them in the `innerHTML` string on line 1011. This change should be made only within the `createWidgetStructure` function, as shown. 

Steps:
- Add a helper function within portfolai/staticfiles/home/js/stock.js named `escapeHTML`.
- Modify line 1011 to use `escapeHTML` on both `symbol` and `exchange` in the `innerHTML` assignment.
- No additional imports are required since the escaping can be implemented locally.
- Ensure that only these variables are escaped (other hardcoded or controlled strings do not require it).
- No changes to business logic or appearance; only the escaping of interpolated variables changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
