### PR TITLE
Potential fix for code scanning alert no. 27: DOM text reinterpreted as HTML

### DIFF
--- a/portfolai/core/static/home/js/modals.js
+++ b/portfolai/core/static/home/js/modals.js
@@ -3,6 +3,16 @@
  * Handles all modal interactions and animations
  */
 
+// Simple HTML escaping for text insertion
+function escapeHTML(str) {
+  if (!str) return '';
+  return str.replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // Modal DOM references
 const loginModal = document.getElementById('loginModal');
 const registerModal = document.getElementById('registerModal');
@@ -77,7 +87,7 @@ function showAnalysisModal(symbol, analysis, isFallback) {
               </div>
               <div>
                 <h2 class="text-2xl font-bold">PortfolAI Analysis</h2>
-                <p class="text-purple-200 text-sm">AI-Powered Stock Analysis for <span id="analysisSymbol" class="font-semibold">${symbol}</span></p>
+                <p class="text-purple-200 text-sm">AI-Powered Stock Analysis for <span id="analysisSymbol" class="font-semibold">${escapeHTML(symbol)}</span></p>
               </div>
             </div>
             <button id="closeAnalysisModal" class="text-white hover:text-purple-200 transition-colors duration-200 p-2 rounded-lg hover:bg-white hover:bg-opacity-10">


### PR DESCRIPTION
Potential fix for [https://github.com/eduran04/PortfolAI-CS4300-Fall-2024-Group-4/security/code-scanning/27](https://github.com/eduran04/PortfolAI-CS4300-Fall-2024-Group-4/security/code-scanning/27)

To fix this vulnerability, we must ensure that any untrusted user data interpolated into HTML, specifically `symbol`, is properly escaped for HTML meta-characters before being injected via `innerHTML`. The codebase already provides an `escapeHTML(str)` function in `stock.js` for this purpose. The cleanest solution is to escape `symbol` with this function before injecting it into the modal HTML.  
Specifically:  
- In `modals.js`, in the template literal used for `analysisModal.innerHTML` (line 68 onward), replace `${symbol}` with an escaped value.
- The escape function must be available in `modals.js`. Since it's defined in `stock.js`, we need to either duplicate it in `modals.js` or import/reuse it (since these are static files, duplicating is simplest and safest; no module system is guaranteed).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
